### PR TITLE
Handle HTTP provider auth unmarshalling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # UTCP
+
+Universal Tool Calling Protocol (UTCP) reference implementation.
+
+UTCP is an attempt to standardise how a client can discover and call
+"tools" (or APIs) no matter what transport they live behind.  Each
+provider describes a transport (HTTP, CLI, GraphQL and so on) and a set
+of tools exposed by that transport.  This repository contains a small
+Go client that can load provider definitions, register them at runtime
+and then invoke the discovered tools.
+
+Only a handful of transports are sketched out and several components
+are intentionally left as stubs.  The goal of the code is to
+demonstrate the basic flow rather than provide a production ready
+implementation.
+
+## Getting Started
+
+To experiment with the client you can load one of the example provider
+configurations and register it with a new `UtcpClient` instance.
+
+Example provider configurations are located in the [examples](./examples/) directory.
+These files can be loaded by the client using `UtcpClientConfig`:
+
+```go
+cfg := &UTCP.UtcpClientConfig{
+    ProvidersFilePath: "examples/http_provider.json",
+}
+client, err := UTCP.NewUtcpClient(context.Background(), cfg, nil, nil)
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+The sample `http_provider.json` demonstrates how to specify an HTTP provider
+with API key authentication.  Provider configuration files are JSON arrays so
+multiple providers can be loaded at once.
+
+Run `go run ./examples` to execute a small program that loads this provider,
+registers it with the client and calls the first discovered tool.
+
+## Provider Types
+
+The client supports a number of provider types, each corresponding to a
+different transport.  Only a subset is implemented but the JSON
+configuration allows for the following kinds of providers:
+
+- `http` and `http_stream` for REST style APIs
+- `sse` for Server Sent Events streams
+- `cli` for command line tools
+- `text` to load tools from text files
+- `graphql`, `grpc`, `websocket`, `tcp`, `udp`, `webrtc` and `mcp` are
+  defined but largely unimplemented in this repository.

--- a/examples/http_provider.json
+++ b/examples/http_provider.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Example HTTP Provider",
+    "provider_type": "http",
+    "http_method": "GET",
+    "url": "https://api.example.com/resource",
+    "content_type": "application/json",
+    "auth": {
+      "auth_type": "api_key",
+      "api_key": "my-secret-api-key",
+      "var_name": "X-Api-Key",
+      "location": "header"
+    },
+    "headers": {
+      "Accept": "application/json"
+    }
+  }
+]

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+
+	UTCP "github.com/Raezil/UTCP"
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := UTCP.NewUtcpClient(ctx, &UTCP.UtcpClientConfig{}, nil, nil)
+	if err != nil {
+		log.Fatalf("failed to create client: %v", err)
+	}
+
+	// Load and register the example provider
+	data, err := ioutil.ReadFile("http_provider.json")
+	if err != nil {
+		log.Fatalf("read provider: %v", err)
+	}
+	var list []map[string]any
+	if err := json.Unmarshal(data, &list); err != nil || len(list) == 0 {
+		log.Fatalf("decode provider list: %v", err)
+	}
+	blob, _ := json.Marshal(list[0])
+	prov, err := UTCP.UnmarshalProvider(blob)
+	if err != nil {
+		log.Fatalf("unmarshal provider: %v", err)
+	}
+	tools, err := client.RegisterToolProvider(ctx, prov)
+	if err != nil {
+		log.Fatalf("register provider: %v", err)
+	}
+	log.Printf("registered %d tool(s)", len(tools))
+
+	// Invoke the first discovered tool if available
+	if len(tools) > 0 {
+		result, err := client.CallTool(ctx, tools[0].Name, map[string]any{})
+		if err != nil {
+			log.Fatalf("tool call failed: %v", err)
+		}
+		log.Printf("tool output: %v", result)
+	}
+}

--- a/provider.go
+++ b/provider.go
@@ -190,40 +190,209 @@ func UnmarshalProvider(data []byte) (Provider, error) {
 		return nil, err
 	}
 
-	var p Provider
 	switch base.ProviderType {
 	case ProviderHTTP:
-		p = &HttpProvider{}
+		return unmarshalHttpProvider(data)
 	case ProviderSSE:
-		p = &SSEProvider{}
+		return unmarshalSSEProvider(data)
 	case ProviderHTTPStream:
-		p = &StreamableHttpProvider{}
+		return unmarshalStreamableHttpProvider(data)
 	case ProviderCLI:
-		p = &CliProvider{}
+		p := &CliProvider{}
+		if err := json.Unmarshal(data, p); err != nil {
+			return nil, err
+		}
+		return p, nil
 	case ProviderWebSocket:
-		p = &WebSocketProvider{}
+		return unmarshalWebSocketProvider(data)
 	case ProviderGRPC:
-		p = &GRPCProvider{}
+		return unmarshalGRPCProvider(data)
 	case ProviderGraphQL:
-		p = &GraphQLProvider{}
+		return unmarshalGraphQLProvider(data)
 	case ProviderTCP:
-		p = &TCPProvider{}
+		p := &TCPProvider{}
+		if err := json.Unmarshal(data, p); err != nil {
+			return nil, err
+		}
+		return p, nil
 	case ProviderUDP:
-		p = &UDPProvider{}
+		p := &UDPProvider{}
+		if err := json.Unmarshal(data, p); err != nil {
+			return nil, err
+		}
+		return p, nil
 	case ProviderWebRTC:
-		p = &WebRTCProvider{}
+		p := &WebRTCProvider{}
+		if err := json.Unmarshal(data, p); err != nil {
+			return nil, err
+		}
+		return p, nil
 	case ProviderMCP:
-		p = &MCPProvider{}
+		p := &MCPProvider{}
+		if err := json.Unmarshal(data, p); err != nil {
+			return nil, err
+		}
+		return p, nil
 	case ProviderText:
-		p = &TextProvider{}
+		p := &TextProvider{}
+		if err := json.Unmarshal(data, p); err != nil {
+			return nil, err
+		}
+		return p, nil
 	default:
 		return nil, fmt.Errorf("unsupported provider_type %q", base.ProviderType)
 	}
+}
 
-	if err := json.Unmarshal(data, p); err != nil {
+func unmarshalHttpProvider(data []byte) (*HttpProvider, error) {
+	type Alias HttpProvider
+	aux := struct {
+		*Alias
+		Auth json.RawMessage `json:"auth"`
+	}{Alias: (*Alias)(&HttpProvider{})}
+	if err := json.Unmarshal(data, &aux); err != nil {
 		return nil, err
 	}
-	return p, nil
+	hp := (*HttpProvider)(aux.Alias)
+	if len(aux.Auth) > 0 {
+		auth, err := unmarshalAuth(aux.Auth)
+		if err != nil {
+			return nil, err
+		}
+		hp.Auth = &auth
+	}
+	return hp, nil
+}
+
+func unmarshalSSEProvider(data []byte) (*SSEProvider, error) {
+	type Alias SSEProvider
+	aux := struct {
+		*Alias
+		Auth json.RawMessage `json:"auth"`
+	}{Alias: (*Alias)(&SSEProvider{})}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return nil, err
+	}
+	sp := (*SSEProvider)(aux.Alias)
+	if len(aux.Auth) > 0 {
+		auth, err := unmarshalAuth(aux.Auth)
+		if err != nil {
+			return nil, err
+		}
+		sp.Auth = &auth
+	}
+	return sp, nil
+}
+
+func unmarshalStreamableHttpProvider(data []byte) (*StreamableHttpProvider, error) {
+	type Alias StreamableHttpProvider
+	aux := struct {
+		*Alias
+		Auth json.RawMessage `json:"auth"`
+	}{Alias: (*Alias)(&StreamableHttpProvider{})}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return nil, err
+	}
+	sp := (*StreamableHttpProvider)(aux.Alias)
+	if len(aux.Auth) > 0 {
+		auth, err := unmarshalAuth(aux.Auth)
+		if err != nil {
+			return nil, err
+		}
+		sp.Auth = &auth
+	}
+	return sp, nil
+}
+
+func unmarshalWebSocketProvider(data []byte) (*WebSocketProvider, error) {
+	type Alias WebSocketProvider
+	aux := struct {
+		*Alias
+		Auth json.RawMessage `json:"auth"`
+	}{Alias: (*Alias)(&WebSocketProvider{})}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return nil, err
+	}
+	wp := (*WebSocketProvider)(aux.Alias)
+	if len(aux.Auth) > 0 {
+		auth, err := unmarshalAuth(aux.Auth)
+		if err != nil {
+			return nil, err
+		}
+		wp.Auth = &auth
+	}
+	return wp, nil
+}
+
+func unmarshalGRPCProvider(data []byte) (*GRPCProvider, error) {
+	type Alias GRPCProvider
+	aux := struct {
+		*Alias
+		Auth json.RawMessage `json:"auth"`
+	}{Alias: (*Alias)(&GRPCProvider{})}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return nil, err
+	}
+	gp := (*GRPCProvider)(aux.Alias)
+	if len(aux.Auth) > 0 {
+		auth, err := unmarshalAuth(aux.Auth)
+		if err != nil {
+			return nil, err
+		}
+		gp.Auth = &auth
+	}
+	return gp, nil
+}
+
+func unmarshalGraphQLProvider(data []byte) (*GraphQLProvider, error) {
+	type Alias GraphQLProvider
+	aux := struct {
+		*Alias
+		Auth json.RawMessage `json:"auth"`
+	}{Alias: (*Alias)(&GraphQLProvider{})}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return nil, err
+	}
+	gp := (*GraphQLProvider)(aux.Alias)
+	if len(aux.Auth) > 0 {
+		auth, err := unmarshalAuth(aux.Auth)
+		if err != nil {
+			return nil, err
+		}
+		gp.Auth = &auth
+	}
+	return gp, nil
+}
+
+func unmarshalAuth(data []byte) (Auth, error) {
+	var base struct {
+		AuthType AuthType `json:"auth_type"`
+	}
+	if err := json.Unmarshal(data, &base); err != nil {
+		return nil, err
+	}
+	switch base.AuthType {
+	case APIKeyType:
+		var a ApiKeyAuth
+		if err := json.Unmarshal(data, &a); err != nil {
+			return nil, err
+		}
+		return &a, nil
+	case BasicType:
+		var a BasicAuth
+		if err := json.Unmarshal(data, &a); err != nil {
+			return nil, err
+		}
+		return &a, nil
+	case OAuth2Type:
+		var a OAuth2Auth
+		if err := json.Unmarshal(data, &a); err != nil {
+			return nil, err
+		}
+		return &a, nil
+	default:
+		return nil, fmt.Errorf("unsupported auth_type %q", base.AuthType)
+	}
 }
 
 // (Assuming Auth, ApiKeyAuth, BasicAuth, OAuth2Auth come from your shared/auth package)

--- a/utcp_client.go
+++ b/utcp_client.go
@@ -140,40 +140,9 @@ func (c *UtcpClient) loadProviders(ctx context.Context, path string) error {
 		// substitute inline variables first
 		subbed := c.replaceVarsInAny(raw, c.config).(map[string]any)
 
-		// decode into the right Provider struct
-		var prov Provider
-		switch ptype {
-		case "http":
-			prov = &HttpProvider{}
-		case "cli":
-			prov = &CliProvider{}
-		case "sse":
-			prov = &SSEProvider{}
-		case "http_stream":
-			prov = &StreamableHttpProvider{}
-		case "websocket":
-			prov = &WebSocketProvider{}
-		case "grpc":
-			prov = &GRPCProvider{}
-		case "graphql":
-			prov = &GraphQLProvider{}
-		case "tcp":
-			prov = &TCPProvider{}
-		case "udp":
-			prov = &UDPProvider{}
-		case "webrtc":
-			prov = &WebRTCProvider{}
-		case "mcp":
-			prov = &MCPProvider{}
-		case "text":
-			prov = &TextProvider{}
-		default:
-			fmt.Fprintf(os.Stderr, "warning: unsupported provider type %q, skipping\n", ptype)
-			continue
-		}
-
 		blob, _ := json.Marshal(subbed)
-		if err := json.Unmarshal(blob, prov); err != nil {
+		prov, err := UnmarshalProvider(blob)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "error decoding provider %q: %v\n", ptype, err)
 			continue
 		}


### PR DESCRIPTION
## Summary
- parse `auth` blocks when unmarshalling provider configs
- ensure clients use `UnmarshalProvider` when loading provider configs
- add example HTTP provider configuration
- document example usage in README
- add an example `main.go` in the `examples` directory
- demonstrate registering the provider and calling a tool in `main.go`
- write better README describing UTCP

## Testing
- `go vet ./...` *(fails: Forbidden - proxy.golang.org)*
- `go test ./...` *(fails: Forbidden - proxy.golang.org)*
- `go build ./...` *(fails: Forbidden - proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_687803e3e38883229cd56cfb7164ad99