### PR TITLE
Fix nil workingDir panic in CLI transport

### DIFF
--- a/cli_transport.go
+++ b/cli_transport.go
@@ -103,7 +103,11 @@ func (t *CliTransport) RegisterToolProvider(
 	cmdArgs := parts[1:]
 	env := t.prepareEnv(cliProv)
 
-	stdout, stderr, code, err := t.executeCommand(ctx, cmdPath, cmdArgs, env, *cliProv.WorkingDir, "")
+	workDir := ""
+	if cliProv.WorkingDir != nil {
+		workDir = *cliProv.WorkingDir
+	}
+	stdout, stderr, code, err := t.executeCommand(ctx, cmdPath, cmdArgs, env, workDir, "")
 	if err != nil && code != 0 {
 		return nil, err
 	}
@@ -199,7 +203,11 @@ func (t *CliTransport) CallTool(
 	cmdArgs = append(cmdArgs, t.formatArguments(args)...)
 	env := t.prepareEnv(cliProv)
 
-	stdout, stderr, code, err := t.executeCommand(ctx, cmdPath, cmdArgs, env, *cliProv.WorkingDir, "")
+	workDir := ""
+	if cliProv.WorkingDir != nil {
+		workDir = *cliProv.WorkingDir
+	}
+	stdout, stderr, code, err := t.executeCommand(ctx, cmdPath, cmdArgs, env, workDir, "")
 	output := stdout
 	if err != nil {
 		t.logError(fmt.Sprintf("Error calling tool %s: %v", toolName, err))


### PR DESCRIPTION
## Summary
- avoid nil pointer dereference when CliProvider has no WorkingDir
- ensure CLI tools run even if working directory is not set

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687893dfce0c832284948c8ff9ce8336