### PR TITLE
Add transport tests

### DIFF
--- a/graphql_transport_test.go
+++ b/graphql_transport_test.go
@@ -1,0 +1,57 @@
+package UTCP
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGraphQLClientTransport_RegisterAndCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Query     string                 `json:"query"`
+			Variables map[string]interface{} `json:"variables"`
+		}
+		json.NewDecoder(r.Body).Decode(&req)
+		if strings.Contains(req.Query, "__schema") {
+			w.Header().Set("Content-Type", "application/json")
+			resp := map[string]interface{}{"data": map[string]interface{}{"__schema": map[string]interface{}{
+				"queryType":    map[string]interface{}{"fields": []map[string]interface{}{{"name": "hello", "description": "hi"}}},
+				"mutationType": map[string]interface{}{"fields": []map[string]interface{}{}}}}}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		if strings.Contains(req.Query, "hello") {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{"hello": "world"}})
+			return
+		}
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	prov := &GraphQLProvider{
+		BaseProvider: BaseProvider{Name: "gql", ProviderType: ProviderGraphQL},
+		URL:          server.URL,
+	}
+	tr := NewGraphQLClientTransport(nil)
+	ctx := context.Background()
+	tools, err := tr.RegisterToolProvider(ctx, prov)
+	if err != nil {
+		t.Fatalf("register error: %v", err)
+	}
+	if len(tools) != 0 {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+
+	res, err := tr.CallTool(ctx, "hello", map[string]interface{}{"name": "bob"}, prov, nil)
+	if err != nil {
+		t.Fatalf("call error: %v", err)
+	}
+	if res != "world" {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}

--- a/http_transport_test.go
+++ b/http_transport_test.go
@@ -1,0 +1,50 @@
+package UTCP
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHttpClientTransport_RegisterAndCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manual":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"version":"1.0","tools":[{"name":"ping","description":"Ping"}]}`))
+		case "/ping":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"pong":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	prov := &HttpProvider{
+		BaseProvider: BaseProvider{Name: "test", ProviderType: ProviderHTTP},
+		HTTPMethod:   http.MethodGet,
+		URL:          server.URL + "/manual",
+	}
+
+	tr := NewHttpClientTransport(nil)
+	ctx := context.Background()
+	tools, err := tr.RegisterToolProvider(ctx, prov)
+	if err != nil {
+		t.Fatalf("register error: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "ping" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+
+	prov.URL = server.URL + "/ping"
+	res, err := tr.CallTool(ctx, "ping", map[string]any{}, prov, nil)
+	if err != nil {
+		t.Fatalf("call error: %v", err)
+	}
+	m, ok := res.(map[string]interface{})
+	if !ok || m["pong"] != true {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}

--- a/mcp_transport_test.go
+++ b/mcp_transport_test.go
@@ -1,0 +1,27 @@
+package UTCP
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMCPClientTransport_RegisterAndCall(t *testing.T) {
+	tr := NewMCPTransport(nil)
+	prov := &MCPProvider{BaseProvider: BaseProvider{Name: "mcp", ProviderType: ProviderMCP}, Config: McpConfig{}}
+	ctx := context.Background()
+	tools, err := tr.RegisterToolProvider(ctx, prov)
+	if err != nil {
+		t.Fatalf("register error: %v", err)
+	}
+	if tools != nil {
+		t.Fatalf("expected nil tools, got %v", tools)
+	}
+
+	if err := tr.DeregisterToolProvider(ctx, prov); err != nil {
+		t.Fatalf("deregister error: %v", err)
+	}
+
+	if _, err := tr.CallTool(ctx, "foo", nil, prov, nil); err == nil {
+		t.Fatalf("expected call error")
+	}
+}

--- a/sse_client_transport_test.go
+++ b/sse_client_transport_test.go
@@ -1,0 +1,52 @@
+package UTCP
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSSEClientTransport_RegisterAndCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/tools":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"version":"1.0","tools":[{"name":"echo","description":"Echo"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/echo":
+			var in map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&in)
+			out, _ := json.Marshal(map[string]interface{}{"result": in["msg"]})
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(out)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	prov := &SSEProvider{
+		BaseProvider: BaseProvider{Name: "sse", ProviderType: ProviderSSE},
+		URL:          server.URL + "/tools",
+	}
+	tr := NewSSETransport(nil)
+	ctx := context.Background()
+	tools, err := tr.RegisterToolProvider(ctx, prov)
+	if err != nil {
+		t.Fatalf("register error: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "echo" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+
+	prov.URL = server.URL
+	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{"msg": "hi"}, prov, nil)
+	if err != nil {
+		t.Fatalf("call error: %v", err)
+	}
+	m, ok := res.(map[string]interface{})
+	if !ok || m["result"] != "hi" {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}

--- a/streamable_transport_test.go
+++ b/streamable_transport_test.go
@@ -1,0 +1,53 @@
+package UTCP
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStreamableHTTPClientTransport_RegisterAndCall(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/tools":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"version":"1.0","tools":[{"name":"echo","description":"Echo"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/echo":
+			var in map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&in)
+			out, _ := json.Marshal(map[string]interface{}{"result": in["msg"]})
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(out)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	prov := &StreamableHttpProvider{
+		BaseProvider: BaseProvider{Name: "stream", ProviderType: ProviderHTTPStream},
+		URL:          server.URL + "/tools",
+		HTTPMethod:   http.MethodGet,
+	}
+	tr := NewStreamableHTTPTransport(nil)
+	ctx := context.Background()
+	tools, err := tr.RegisterToolProvider(ctx, prov)
+	if err != nil {
+		t.Fatalf("register error: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "echo" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+
+	prov.URL = server.URL
+	res, err := tr.CallTool(ctx, "echo", map[string]interface{}{"msg": "hi"}, prov, nil)
+	if err != nil {
+		t.Fatalf("call error: %v", err)
+	}
+	m, ok := res.(map[string]interface{})
+	if !ok || m["result"] != "hi" {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}

--- a/text_client_transport_test.go
+++ b/text_client_transport_test.go
@@ -1,0 +1,51 @@
+package UTCP
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestTextClientTransport_RegisterAndCall(t *testing.T) {
+	tmp, err := os.CreateTemp("", "manual*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.WriteString(`{"tools":[{"name":"hello","description":"Hi"}]}`)
+	tmp.Close()
+
+	prov := &TextProvider{
+		BaseProvider: BaseProvider{Name: "text", ProviderType: ProviderText},
+		FilePath:     tmp.Name(),
+	}
+	tr := NewTextTransport("")
+	ctx := context.Background()
+	tools, err := tr.RegisterToolProvider(ctx, prov)
+	if err != nil {
+		t.Fatalf("register error: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "hello" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+
+	tr.tools["hello"] = Tool{Name: "hello", Handler: func(_ map[string]interface{}, _ map[string]interface{}) (map[string]interface{}, error) {
+		return map[string]interface{}{"ok": true}, nil
+	}}
+
+	res, err := tr.CallTool(ctx, "hello", map[string]interface{}{}, prov, nil)
+	if err != nil {
+		t.Fatalf("call error: %v", err)
+	}
+	m := res.(map[string]interface{})
+	if m["ok"] != true {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+
+	if err := tr.DeregisterToolProvider(ctx, prov); err != nil {
+		t.Fatalf("deregister error: %v", err)
+	}
+	if len(tr.tools) != 0 {
+		t.Fatalf("expected tools to be cleared")
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for HTTP, SSE, streaming HTTP, GraphQL, text and MCP transports

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878b4a69de08322b1f04f6456edc6f3