### PR TITLE
Improve test coverage

### DIFF
--- a/http_transport_auth_test.go
+++ b/http_transport_auth_test.go
@@ -1,0 +1,74 @@
+package UTCP
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHttpClientTransport_applyAuth(t *testing.T) {
+	tr := NewHttpClientTransport(nil)
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	keyAuth := &ApiKeyAuth{AuthType: APIKeyType, APIKey: "k", VarName: "X", Location: "header"}
+	var a Auth = keyAuth
+	if err := tr.applyAuth(req, &HttpProvider{Auth: &a}); err != nil {
+		t.Fatalf("applyAuth err: %v", err)
+	}
+	if req.Header.Get("X") != "k" {
+		t.Fatalf("header not set")
+	}
+
+	req2, _ := http.NewRequest("GET", "http://e.com?q=1", nil)
+	keyAuth.Location = "query"
+	a = keyAuth
+	if err := tr.applyAuth(req2, &HttpProvider{Auth: &a}); err != nil {
+		t.Fatalf("applyAuth query err: %v", err)
+	}
+	if req2.URL.Query().Get("X") != "k" {
+		t.Fatalf("query not set")
+	}
+
+	req3, _ := http.NewRequest("GET", "http://e.com", nil)
+	keyAuth.Location = "cookie"
+	a = keyAuth
+	if err := tr.applyAuth(req3, &HttpProvider{Auth: &a}); err != nil {
+		t.Fatalf("applyAuth cookie err: %v", err)
+	}
+	if c, err := req3.Cookie("X"); err != nil || c.Value != "k" {
+		t.Fatalf("cookie not set")
+	}
+
+	basic := &BasicAuth{AuthType: BasicType, Username: "u", Password: "p"}
+	req4, _ := http.NewRequest("GET", "http://e.com", nil)
+	a = basic
+	if err := tr.applyAuth(req4, &HttpProvider{Auth: &a}); err != nil {
+		t.Fatalf("basic err: %v", err)
+	}
+	if req4.Header.Get("Authorization") == "" {
+		t.Fatalf("basic header missing")
+	}
+}
+
+func TestHttpClientTransport_handleOAuth2(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"access_token":"tok"}`))
+	}))
+	defer server.Close()
+
+	tr := NewHttpClientTransport(nil)
+	tr.httpClient = server.Client()
+	oauth := &OAuth2Auth{AuthType: OAuth2Type, TokenURL: server.URL, ClientID: "id", ClientSecret: "sec", Scope: ptr("scope")}
+	tok, err := tr.handleOAuth2(context.Background(), oauth)
+	if err != nil || tok != "tok" {
+		t.Fatalf("got %s err %v", tok, err)
+	}
+	// second call should use cached token
+	tok2, err := tr.handleOAuth2(context.Background(), oauth)
+	if err != nil || tok2 != "tok" {
+		t.Fatalf("cached token %s err %v", tok2, err)
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/provider_additional_test.go
+++ b/provider_additional_test.go
@@ -1,0 +1,69 @@
+package UTCP
+
+import "testing"
+
+func TestUnmarshalAuth_Types(t *testing.T) {
+	apiJSON := []byte(`{"auth_type":"api_key","api_key":"secret","var_name":"X","location":"header"}`)
+	a, err := unmarshalAuth(apiJSON)
+	if err != nil {
+		t.Fatalf("api key err: %v", err)
+	}
+	if _, ok := a.(*ApiKeyAuth); !ok {
+		t.Fatalf("expected ApiKeyAuth got %T", a)
+	}
+
+	basicJSON := []byte(`{"auth_type":"basic","username":"u","password":"p"}`)
+	b, err := unmarshalAuth(basicJSON)
+	if err != nil {
+		t.Fatalf("basic err: %v", err)
+	}
+	if _, ok := b.(*BasicAuth); !ok {
+		t.Fatalf("expected BasicAuth got %T", b)
+	}
+
+	oauthJSON := []byte(`{"auth_type":"oauth2","token_url":"http://t","client_id":"cid","client_secret":"sec"}`)
+	o, err := unmarshalAuth(oauthJSON)
+	if err != nil {
+		t.Fatalf("oauth err: %v", err)
+	}
+	if _, ok := o.(*OAuth2Auth); !ok {
+		t.Fatalf("expected OAuth2Auth got %T", o)
+	}
+}
+
+func TestUnmarshalProvider_MoreTypes(t *testing.T) {
+	cases := []struct {
+		json string
+		typ  ProviderType
+	}{
+		{`{"provider_type":"http_stream","name":"hs","url":"http://x","http_method":"GET","auth":{"auth_type":"api_key","api_key":"k","var_name":"X","location":"header"}}`, ProviderHTTPStream},
+		{`{"provider_type":"websocket","name":"ws","url":"ws://x","auth":{"auth_type":"api_key","api_key":"k","var_name":"X","location":"header"}}`, ProviderWebSocket},
+		{`{"provider_type":"grpc","name":"g","host":"h","port":1,"service_name":"s","method_name":"m","auth":{"auth_type":"api_key","api_key":"k","var_name":"X","location":"header"}}`, ProviderGRPC},
+		{`{"provider_type":"graphql","name":"gql","url":"http://g","operation_type":"query","auth":{"auth_type":"api_key","api_key":"k","var_name":"X","location":"header"}}`, ProviderGraphQL},
+		{`{"provider_type":"text","name":"txt","file_path":"/tmp/f"}`, ProviderText},
+		{`{"provider_type":"webrtc","name":"w","signaling_server":"s","peer_id":"p","data_channel_name":"d"}`, ProviderWebRTC},
+	}
+	for _, c := range cases {
+		p, err := UnmarshalProvider([]byte(c.json))
+		if err != nil {
+			t.Errorf("unmarshal error for %s: %v", c.typ, err)
+			continue
+		}
+		if p.Type() != c.typ {
+			t.Errorf("type mismatch: got %s want %s", p.Type(), c.typ)
+		}
+	}
+	if _, err := UnmarshalProvider([]byte(`{"provider_type":"unknown"}`)); err == nil {
+		t.Errorf("expected error for unknown provider")
+	}
+}
+
+func TestMCPProvider_Basic(t *testing.T) {
+	p := NewMCPProvider("n")
+	if p.Type() != ProviderType("mcp") {
+		t.Fatalf("Type mismatch")
+	}
+	if p.Name() != "n" {
+		t.Fatalf("Name mismatch")
+	}
+}

--- a/transport_deregister_test.go
+++ b/transport_deregister_test.go
@@ -1,0 +1,20 @@
+package UTCP
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSSEAndStreamableDeregister(t *testing.T) {
+	sse := NewSSETransport(nil)
+	sh := &SSEProvider{BaseProvider: BaseProvider{Name: "s", ProviderType: ProviderSSE}}
+	if err := sse.DeregisterToolProvider(context.Background(), sh); err != nil {
+		t.Fatalf("sse deregister error: %v", err)
+	}
+
+	stream := NewStreamableHTTPTransport(nil)
+	sth := &StreamableHttpProvider{BaseProvider: BaseProvider{Name: "h", ProviderType: ProviderHTTPStream}}
+	if err := stream.DeregisterToolProvider(context.Background(), sth); err != nil {
+		t.Fatalf("stream deregister error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add extra tests for authentication types and provider parsing
- exercise HTTP client authentication helpers
- check deregister on SSE and streamable transports

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878c7a7140483229ba7a6586b2827d3