### PR TITLE
Increase coverage to exceed 80%

### DIFF
--- a/cli_transport_additional_test.go
+++ b/cli_transport_additional_test.go
@@ -1,0 +1,54 @@
+package UTCP
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestCliTransportLogging(t *testing.T) {
+	msgs := []string{}
+	tr := NewCliTransport(func(f string, args ...interface{}) { msgs = append(msgs, fmt.Sprintf(f, args...)) })
+	tr.logInfo("hello")
+	tr.logError("bad")
+	if len(msgs) != 2 || msgs[0] == msgs[1] {
+		t.Fatalf("unexpected log messages: %v", msgs)
+	}
+}
+
+func TestHttpAndGraphQLDeregister(t *testing.T) {
+	h := NewHttpClientTransport(nil)
+	if err := h.DeregisterToolProvider(context.Background(), &HttpProvider{}); err != nil {
+		t.Fatalf("http deregister err: %v", err)
+	}
+	g := NewGraphQLClientTransport(nil)
+	if err := g.DeregisterToolProvider(context.Background(), &GraphQLProvider{}); err != nil {
+		t.Fatalf("gql deregister err: %v", err)
+	}
+}
+
+func TestExtractManualAdditional(t *testing.T) {
+	tr := NewCliTransport(nil)
+	mixed := `line
+{"tools":[{"name":"a","description":"d"}]}
+other`
+	tools := tr.extractManual(mixed, "p")
+	if len(tools) != 1 || tools[0].Name != "a" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+}
+
+func TestExecuteCommandFailures(t *testing.T) {
+	tr := NewCliTransport(nil)
+	ctx := context.Background()
+
+	_, _, code, err := tr.executeCommand(ctx, "sh", []string{"-c", "echo hi; exit 1"}, nil, "", "")
+	if err != nil || code != 1 {
+		t.Fatalf("expected exit code 1, got %d err %v", code, err)
+	}
+
+	_, _, _, err = tr.executeCommand(ctx, "nonexistent_command_xyz", nil, nil, "", "")
+	if err == nil {
+		t.Fatalf("expected error for missing command")
+	}
+}

--- a/graphql_transport_additional_test.go
+++ b/graphql_transport_additional_test.go
@@ -1,0 +1,147 @@
+package UTCP
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// helper pointer to string
+func sptr(s string) *string { return &s }
+
+// TestGraphQLTransport_prepareHeaders various auth cases.
+func TestGraphQLTransport_prepareHeaders(t *testing.T) {
+	tr := NewGraphQLClientTransport(nil)
+	ctx := context.Background()
+	prov := &GraphQLProvider{URL: "https://example.com"}
+
+	// no auth
+	hdr, err := tr.prepareHeaders(ctx, prov)
+	if err != nil || len(hdr) != 0 {
+		t.Fatalf("unexpected headers %v err %v", hdr, err)
+	}
+
+	// api key header
+	a := &ApiKeyAuth{AuthType: APIKeyType, APIKey: "k", VarName: "X", Location: "header"}
+	var auth Auth = a
+	prov.Auth = &auth
+	hdr, err = tr.prepareHeaders(ctx, prov)
+	if err != nil || hdr["X"] != "k" {
+		t.Fatalf("apikey header failed: %v %v", hdr, err)
+	}
+
+	// invalid api key location
+	a.Location = "query"
+	hdr, err = tr.prepareHeaders(ctx, prov)
+	if err == nil {
+		t.Fatalf("expected error for bad location")
+	}
+
+	// basic auth
+	b := &BasicAuth{AuthType: BasicType, Username: "u", Password: "p"}
+	auth = b
+	prov.Auth = &auth
+	hdr, err = tr.prepareHeaders(ctx, prov)
+	if err != nil || hdr["Authorization"] == "" {
+		t.Fatalf("basic auth failed: %v %v", hdr, err)
+	}
+
+	// oauth2 auth using test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"access_token": "tok"})
+	}))
+	defer ts.Close()
+	o := &OAuth2Auth{AuthType: OAuth2Type, TokenURL: ts.URL, ClientID: "id", ClientSecret: "sec", Scope: sptr("scope")}
+	auth = o
+	prov.Auth = &auth
+	hdr, err = tr.prepareHeaders(ctx, prov)
+	if err != nil || hdr["Authorization"] != "Bearer tok" {
+		t.Fatalf("oauth2 auth failed: %v %v", hdr, err)
+	}
+
+	// verify Close clears cache
+	tr.Close()
+	if len(tr.oauthTokens) != 0 {
+		t.Fatalf("Close should clear tokens")
+	}
+}
+
+// TestGraphQL_enforceHTTPS ensures invalid URLs are rejected.
+func TestGraphQL_enforceHTTPS(t *testing.T) {
+	tr := NewGraphQLClientTransport(nil)
+	if err := tr.enforceHTTPSOrLocalhost("http://example.com"); err == nil {
+		t.Fatalf("expected error for insecure URL")
+	}
+	if err := tr.enforceHTTPSOrLocalhost("https://good.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestGraphQL_handleOAuth2 covers token caching.
+func TestGraphQL_handleOAuth2(t *testing.T) {
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		json.NewEncoder(w).Encode(map[string]string{"access_token": "tok"})
+	}))
+	defer ts.Close()
+
+	old := http.DefaultClient
+	http.DefaultClient = ts.Client()
+	defer func() { http.DefaultClient = old }()
+
+	tr := NewGraphQLClientTransport(nil)
+	oauth := &OAuth2Auth{AuthType: OAuth2Type, TokenURL: ts.URL, ClientID: "id", ClientSecret: "sec", Scope: sptr("s")}
+	tok, err := tr.handleOAuth2(context.Background(), oauth)
+	if err != nil || tok != "tok" {
+		t.Fatalf("first call failed: %s %v", tok, err)
+	}
+	ts.Close() // further network calls would fail
+	tok2, err := tr.handleOAuth2(context.Background(), oauth)
+	if err != nil || tok2 != "tok" {
+		t.Fatalf("cached call failed: %s %v", tok2, err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 network call, got %d", calls)
+	}
+}
+
+// TestGraphQL_RegisterAndCall_Errors exercises error branches.
+func TestGraphQL_RegisterAndCall_Errors(t *testing.T) {
+	tr := NewGraphQLClientTransport(nil)
+	ctx := context.Background()
+	// wrong provider type
+	if _, err := tr.RegisterToolProvider(ctx, &CliProvider{}); err == nil {
+		t.Fatalf("expected error for wrong provider")
+	}
+	if _, err := tr.CallTool(ctx, "x", nil, &CliProvider{}, nil); err == nil {
+		t.Fatalf("expected error for wrong provider")
+	}
+	prov := &GraphQLProvider{URL: "http://example.com"}
+	if _, err := tr.RegisterToolProvider(ctx, prov); err == nil {
+		t.Fatalf("expected https enforcement error")
+	}
+	if _, err := tr.CallTool(ctx, "foo", nil, prov, nil); err == nil {
+		t.Fatalf("expected https enforcement error")
+	}
+}
+
+// TestGraphQL_CallTool_NoData ensures result map when tool key missing.
+func TestGraphQL_CallTool_NoData(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{"other": 1}})
+	}))
+	defer server.Close()
+	prov := &GraphQLProvider{URL: server.URL}
+	tr := NewGraphQLClientTransport(nil)
+	res, err := tr.CallTool(context.Background(), "foo", nil, prov, nil)
+	if err != nil {
+		t.Fatalf("call error: %v", err)
+	}
+	m, ok := res.(map[string]interface{})
+	if !ok || m["other"] != float64(1) {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}

--- a/http_transport_additional_test.go
+++ b/http_transport_additional_test.go
@@ -1,0 +1,52 @@
+package UTCP
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHttpTransport_Register_InsecureURL(t *testing.T) {
+	tr := NewHttpClientTransport(nil)
+	prov := &HttpProvider{BaseProvider: BaseProvider{Name: "h", ProviderType: ProviderHTTP}, HTTPMethod: http.MethodGet, URL: "http://example.com"}
+	if _, err := tr.RegisterToolProvider(context.Background(), prov); err == nil {
+		t.Fatalf("expected security error")
+	}
+}
+
+func TestHttpTransport_CallTool_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad", http.StatusBadRequest)
+	}))
+	defer server.Close()
+	prov := &HttpProvider{BaseProvider: BaseProvider{Name: "h", ProviderType: ProviderHTTP}, HTTPMethod: http.MethodGet, URL: server.URL}
+	tr := NewHttpClientTransport(nil)
+	_, err := tr.CallTool(context.Background(), "t", map[string]any{}, prov, nil)
+	if err == nil {
+		t.Fatalf("expected error from call")
+	}
+}
+
+func TestHttpTransport_CallTool_PathSub(t *testing.T) {
+	gotPath := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+	prov := &HttpProvider{BaseProvider: BaseProvider{Name: "h", ProviderType: ProviderHTTP}, HTTPMethod: http.MethodGet, URL: server.URL + "/{id}"}
+	tr := NewHttpClientTransport(nil)
+	res, err := tr.CallTool(context.Background(), "t", map[string]any{"id": 5}, prov, nil)
+	if err != nil {
+		t.Fatalf("call error: %v", err)
+	}
+	if gotPath != "/5" {
+		t.Fatalf("path substitution failed: %s", gotPath)
+	}
+	m := res.(map[string]interface{})
+	if m["ok"] != true {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}

--- a/http_transport_auth_test.go
+++ b/http_transport_auth_test.go
@@ -72,3 +72,16 @@ func TestHttpClientTransport_handleOAuth2(t *testing.T) {
 }
 
 func ptr(s string) *string { return &s }
+
+func TestHttpClientTransport_handleOAuth2_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad", http.StatusBadRequest)
+	}))
+	defer server.Close()
+	tr := NewHttpClientTransport(nil)
+	tr.httpClient = server.Client()
+	oauth := &OAuth2Auth{AuthType: OAuth2Type, TokenURL: server.URL, ClientID: "id", ClientSecret: "sec", Scope: ptr("s")}
+	if _, err := tr.handleOAuth2(context.Background(), oauth); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/mcp_transport_additional_test.go
+++ b/mcp_transport_additional_test.go
@@ -1,0 +1,54 @@
+package UTCP
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestMCPTransport_Errors ensures type checks return errors and Is works.
+func TestMCPTransport_Errors(t *testing.T) {
+	tr := NewMCPTransport(nil)
+	ctx := context.Background()
+	// wrong provider for register
+	if _, err := tr.RegisterToolProvider(ctx, &CliProvider{}); err == nil {
+		t.Fatalf("expected error for wrong provider")
+	}
+	// wrong provider for deregister
+	if err := tr.DeregisterToolProvider(ctx, &CliProvider{}); err == nil {
+		t.Fatalf("expected error for wrong provider")
+	}
+	// wrong provider for call
+	if _, err := tr.CallTool(ctx, "t", nil, &CliProvider{}, nil); err == nil {
+		t.Fatalf("expected error for wrong provider")
+	}
+	// proper provider returns notImplErr
+	_, err := tr.CallTool(ctx, "t", nil, NewMCPProvider("m"), nil)
+	if !errors.Is(err, notImplErr{}) {
+		t.Fatalf("expected notImplErr, got %v", err)
+	}
+}
+
+// TestNotImplErr verifies Error and Is behaviour.
+func TestNotImplErr(t *testing.T) {
+	var e error = notImplErr{}
+	target := errors.New("MCP transport invocation not implemented yet")
+	if !errors.Is(e, target) {
+		t.Fatalf("errors.Is failed")
+	}
+	if e.Error() == "" {
+		t.Fatalf("empty error message")
+	}
+}
+
+func TestMCPTransport_SuccessPaths(t *testing.T) {
+	tr := NewMCPTransport(nil)
+	ctx := context.Background()
+	prov := NewMCPProvider("m")
+	if _, err := tr.RegisterToolProvider(ctx, prov); err != nil {
+		t.Fatalf("register err: %v", err)
+	}
+	if err := tr.DeregisterToolProvider(ctx, prov); err != nil {
+		t.Fatalf("deregister err: %v", err)
+	}
+}

--- a/provider_additional_test.go
+++ b/provider_additional_test.go
@@ -67,3 +67,12 @@ func TestMCPProvider_Basic(t *testing.T) {
 		t.Fatalf("Name mismatch")
 	}
 }
+
+func TestUnmarshalAuth_Errors(t *testing.T) {
+	if _, err := unmarshalAuth([]byte(`{"auth_type":"unknown"}`)); err == nil {
+		t.Fatalf("expected error for unknown type")
+	}
+	if _, err := unmarshalAuth([]byte(`{`)); err == nil {
+		t.Fatalf("expected json error")
+	}
+}

--- a/sse_client_transport_additional_test.go
+++ b/sse_client_transport_additional_test.go
@@ -1,0 +1,22 @@
+package UTCP
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestDecodeToolsResponse(t *testing.T) {
+	r := io.NopCloser(strings.NewReader(`{"tools":[{"name":"t","description":"d"}]}`))
+	tools, err := decodeToolsResponse(r)
+	if err != nil || len(tools) != 1 || tools[0].Name != "t" {
+		t.Fatalf("decode err %v tools %+v", err, tools)
+	}
+}
+
+func TestDecodeToolsResponse_Error(t *testing.T) {
+	r := io.NopCloser(strings.NewReader(`bad`))
+	if _, err := decodeToolsResponse(r); err == nil {
+		t.Fatalf("expected error for bad json")
+	}
+}

--- a/tool_additional_test.go
+++ b/tool_additional_test.go
@@ -1,0 +1,40 @@
+package UTCP
+
+import (
+	"testing"
+)
+
+// TestAddToolAndGetTools verifies AddTool and GetTools functions.
+func TestAddToolAndGetTools(t *testing.T) {
+	tools = nil
+	AddTool(Tool{Name: "t1"})
+	AddTool(Tool{Name: "t2"})
+	got := GetTools()
+	if len(got) != 2 || got[0].Name != "t1" || got[1].Name != "t2" {
+		t.Fatalf("unexpected tools slice: %+v", got)
+	}
+}
+
+// TestAddToolPanics ensures AddTool panics when name is empty.
+func TestAddToolPanics(t *testing.T) {
+	defer func() { recover() }()
+	AddTool(Tool{})
+	t.Fatalf("expected panic for unnamed tool")
+}
+
+// TestRegisterToolDefaults uses RegisterTool with nil schemas and expects defaults.
+func TestRegisterToolDefaults(t *testing.T) {
+	tools = nil
+	handler := func(ctx map[string]interface{}, in map[string]interface{}) (map[string]interface{}, error) {
+		return in, nil
+	}
+	prov := &CliProvider{BaseProvider: BaseProvider{Name: "cli", ProviderType: ProviderCLI}}
+	RegisterTool(prov, "echo", "desc", []string{"tag"}, nil, nil, handler)
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	tool := tools[0]
+	if tool.Inputs.Type != "object" || tool.Outputs.Type != "object" {
+		t.Fatalf("expected default schemas, got %+v %+v", tool.Inputs, tool.Outputs)
+	}
+}

--- a/utcp_manual_additional_test.go
+++ b/utcp_manual_additional_test.go
@@ -1,0 +1,10 @@
+package UTCP
+
+import "testing"
+
+func TestNewOpenAPIConverter(t *testing.T) {
+	c := NewOpenAPIConverter(nil, "u", "n")
+	if c.url != "u" || c.name != "n" || c.raw != nil {
+		t.Fatalf("unexpected converter: %+v", c)
+	}
+}


### PR DESCRIPTION
## Summary
- add extensive tests for CLI, HTTP, GraphQL, SSE and MCP transports
- cover tool registration helpers and OpenAPI converter constructor
- include extra provider and auth error cases

## Testing
- `go test ./...`
- `go test ./... -cover`


------
https://chatgpt.com/codex/tasks/task_e_6878cc05c85483229428b423e3efeab9