### PR TITLE
Add local SSE server example

### DIFF
--- a/examples/sse_transport/main.go
+++ b/examples/sse_transport/main.go
@@ -2,29 +2,66 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log"
+	"net/http"
 	"time"
 
-	"github.com/Raezil/UTCP"
+	UTCP "github.com/Raezil/UTCP"
 )
 
 func main() {
+	// 1) Start a mock SSE provider locally
+	go startMockServer(":8080")
 
-	// Optional: SSE transport example (ensure URL is a valid SSE endpoint streaming JSON)
-	// Uncomment and configure the following block if you have a working SSE provider.
+	// 2) Give the server a moment to start
+	time.Sleep(200 * time.Millisecond)
 
-	// SSE example
+	// 3) Run the UTCP client against the local provider
+	runClient("http://localhost:8080")
+}
+
+// startMockServer boots a simple HTTP API that mimics an SSE provider.
+func startMockServer(addr string) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/tools", func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"version": "1.0",
+			"tools": []map[string]interface{}{
+				{"name": "hello", "description": "Returns a greeting"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
+		var in map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		name, _ := in["name"].(string)
+		out := map[string]interface{}{"result": fmt.Sprintf("Hello, %s!", name)}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(out)
+	})
+
+	log.Printf("Mock SSE provider listening on %s...", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
+}
+
+// runClient demonstrates registering and calling a tool via the SSE transport.
+func runClient(baseURL string) {
 	ctx := context.Background()
-	sseLogger := func(format string, args ...interface{}) {
+	logger := func(format string, args ...interface{}) {
 		fmt.Printf("[SSE] "+format+"\n", args...)
 	}
-	sseTransport := UTCP.NewSSETransport(sseLogger)
-	sseProvider := &UTCP.SSEProvider{
-		URL:     "https://your-sse-endpoint.example.com/stream",
-		Headers: map[string]string{"Authorization": "Bearer YOUR_TOKEN"},
-	}
-	//
-	tools, err := sseTransport.RegisterToolProvider(ctx, sseProvider)
+	transport := UTCP.NewSSETransport(logger)
+
+	provider := &UTCP.SSEProvider{URL: baseURL + "/tools"}
+	tools, err := transport.RegisterToolProvider(ctx, provider)
 	if err != nil {
 		panic(fmt.Errorf("failed to register SSE tools: %w", err))
 	}
@@ -32,6 +69,14 @@ func main() {
 	for _, t := range tools {
 		fmt.Printf(" - %s: %s\n", t.Name, t.Description)
 	}
+
+	// Update URL for tool calls
+	provider.URL = baseURL
+	result, err := transport.CallTool(ctx, "hello", map[string]interface{}{"name": "UTCP"}, provider, nil)
+	if err != nil {
+		panic(fmt.Errorf("failed to call tool: %w", err))
+	}
+	fmt.Printf("Tool response: %#v\n", result)
 
 	// Ensure logs flush before exit
 	time.Sleep(500 * time.Millisecond)


### PR DESCRIPTION
## Summary
- implement a local mock SSE provider
- update example to connect to the local server instead of a placeholder URL

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878f2f3262c83228d2998ef2b53d561