### PR TITLE
Refactor MCP transport

### DIFF
--- a/examples/mcp_transport/main.go
+++ b/examples/mcp_transport/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/Raezil/UTCP"
 )
@@ -11,8 +14,9 @@ func main() {
 	// Create a base context
 	ctx := context.Background()
 
-	// Initialize the MCP transport with the default logger
-	transport := UTCP.NewMCPTransport(nil)
+	// Initialize the MCP transport with a custom HTTP client and default logger
+	client := &http.Client{Timeout: 10 * time.Second}
+	transport := UTCP.NewMCPTransportWithClient(client, nil)
 
 	// Create an MCPProvider instance with a name (use your own configuration)
 	provider := UTCP.NewMCPProvider("ExampleProvider")
@@ -28,7 +32,9 @@ func main() {
 
 	// Call a tool via the transport (replace "toolName" and parameters accordingly)
 	result, err := transport.CallTool(ctx, "toolName", map[string]interface{}{"param1": "value1"}, provider, nil)
-	if err != nil {
+	if errors.Is(err, UTCP.ErrNotImplemented) {
+		fmt.Println("Tool calling not implemented yet")
+	} else if err != nil {
 		fmt.Printf("Error invoking tool: %v\n", err)
 	} else {
 		fmt.Printf("Tool result: %v\n", result)

--- a/mcp_transport_additional_test.go
+++ b/mcp_transport_additional_test.go
@@ -22,18 +22,17 @@ func TestMCPTransport_Errors(t *testing.T) {
 	if _, err := tr.CallTool(ctx, "t", nil, &CliProvider{}, nil); err == nil {
 		t.Fatalf("expected error for wrong provider")
 	}
-	// proper provider returns notImplErr
+	// proper provider returns ErrNotImplemented
 	_, err := tr.CallTool(ctx, "t", nil, NewMCPProvider("m"), nil)
-	if !errors.Is(err, notImplErr{}) {
-		t.Fatalf("expected notImplErr, got %v", err)
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Fatalf("expected ErrNotImplemented, got %v", err)
 	}
 }
 
-// TestNotImplErr verifies Error and Is behaviour.
-func TestNotImplErr(t *testing.T) {
-	var e error = notImplErr{}
-	target := errors.New("MCP transport invocation not implemented yet")
-	if !errors.Is(e, target) {
+// TestErrNotImplemented verifies Error and Is behaviour.
+func TestErrNotImplemented(t *testing.T) {
+	var e error = ErrNotImplemented
+	if !errors.Is(e, ErrNotImplemented) {
 		t.Fatalf("errors.Is failed")
 	}
 	if e.Error() == "" {

--- a/mcp_transport_test.go
+++ b/mcp_transport_test.go
@@ -2,6 +2,7 @@ package UTCP
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -21,7 +22,7 @@ func TestMCPClientTransport_RegisterAndCall(t *testing.T) {
 		t.Fatalf("deregister error: %v", err)
 	}
 
-	if _, err := tr.CallTool(ctx, "foo", nil, prov, nil); err == nil {
-		t.Fatalf("expected call error")
+	if _, err := tr.CallTool(ctx, "foo", nil, prov, nil); !errors.Is(err, ErrNotImplemented) {
+		t.Fatalf("expected ErrNotImplemented, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- clean up mcp transport implementation
- expose sentinel errors and helper constructor
- adjust tests for new errors
- update the mcp transport example

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878f62b6cc8832288e0a77ae16bbff2