### PR TITLE
Add UDP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ discovered tools.
 ### Features
 
 * Built-in transports for HTTP, CLI, Server-Sent Events, streaming HTTP,
-  GraphQL, MCP and text-based providers.
+  GraphQL, MCP, UDP and text-based providers.
 * Variable substitution via environment variables or `.env` files using
   `UtcpDotEnv`.
 * In-memory repository for storing providers and tools discovered at

--- a/udp_transport.go
+++ b/udp_transport.go
@@ -1,0 +1,96 @@
+package UTCP
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+)
+
+// UDPTransport implements the ClientTransport interface over UDP.
+type UDPTransport struct {
+	logger func(format string, args ...interface{})
+}
+
+// NewUDPTransport constructs a UDPTransport with optional logging.
+func NewUDPTransport(logger func(format string, args ...interface{})) *UDPTransport {
+	if logger == nil {
+		logger = func(string, ...interface{}) {}
+	}
+	return &UDPTransport{logger: logger}
+}
+
+// writeAndRead sends a packet and waits for a response within timeout.
+func (t *UDPTransport) writeAndRead(ctx context.Context, addr string, timeout time.Duration, payload []byte) ([]byte, error) {
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	} else if timeout > 0 {
+		_ = conn.SetDeadline(time.Now().Add(timeout))
+	}
+	if _, err := conn.Write(payload); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, 65535)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+// RegisterToolProvider discovers tools by sending a DISCOVER message to the server.
+func (t *UDPTransport) RegisterToolProvider(ctx context.Context, prov Provider) ([]Tool, error) {
+	p, ok := prov.(*UDPProvider)
+	if !ok {
+		return nil, errors.New("UDPTransport can only be used with UDPProvider")
+	}
+	addr := fmt.Sprintf("%s:%d", p.Host, p.Port)
+	timeout := time.Duration(p.Timeout) * time.Millisecond
+	resp, err := t.writeAndRead(ctx, addr, timeout, []byte("DISCOVER"))
+	if err != nil {
+		return nil, err
+	}
+	var manual UtcpManual
+	if err := json.Unmarshal(resp, &manual); err != nil {
+		return nil, err
+	}
+	return manual.Tools, nil
+}
+
+// DeregisterToolProvider is a no-op for UDPTransport.
+func (t *UDPTransport) DeregisterToolProvider(ctx context.Context, prov Provider) error {
+	if _, ok := prov.(*UDPProvider); !ok {
+		return errors.New("UDPTransport can only be used with UDPProvider")
+	}
+	return nil
+}
+
+// CallTool sends a JSON request with tool name and arguments and waits for the response.
+func (t *UDPTransport) CallTool(ctx context.Context, toolName string, args map[string]any, prov Provider, l *string) (any, error) {
+	p, ok := prov.(*UDPProvider)
+	if !ok {
+		return nil, errors.New("UDPTransport can only be used with UDPProvider")
+	}
+	addr := fmt.Sprintf("%s:%d", p.Host, p.Port)
+	timeout := time.Duration(p.Timeout) * time.Millisecond
+	payload, err := json.Marshal(map[string]any{"tool": toolName, "args": args})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := t.writeAndRead(ctx, addr, timeout, payload)
+	if err != nil {
+		return nil, err
+	}
+	var result any
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/udp_transport_test.go
+++ b/udp_transport_test.go
@@ -1,0 +1,97 @@
+package UTCP
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"strconv"
+	"testing"
+)
+
+type udpServer struct {
+	conn   *net.UDPConn
+	doneCh chan struct{}
+}
+
+func startUDPServer(handler func([]byte) []byte) (*udpServer, error) {
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		return nil, err
+	}
+	s := &udpServer{conn: conn, doneCh: make(chan struct{})}
+	go func() {
+		buf := make([]byte, 65535)
+		for {
+			n, remote, err := conn.ReadFromUDP(buf)
+			if err != nil {
+				select {
+				case <-s.doneCh:
+					return
+				default:
+					continue
+				}
+			}
+			resp := handler(buf[:n])
+			if resp != nil {
+				conn.WriteToUDP(resp, remote)
+			}
+		}
+	}()
+	return s, nil
+}
+
+func (s *udpServer) addr() string {
+	return s.conn.LocalAddr().String()
+}
+
+func (s *udpServer) close() {
+	close(s.doneCh)
+	s.conn.Close()
+}
+
+func TestUDPTransport_RegisterAndCall(t *testing.T) {
+	server, err := startUDPServer(func(b []byte) []byte {
+		if string(b) == "DISCOVER" {
+			return []byte(`{"version":"1.0","tools":[{"name":"udp_echo","description":"Echo"}]}`)
+		}
+		var req map[string]any
+		_ = json.Unmarshal(b, &req)
+		if req["tool"] == "udp_echo" {
+			args := req["args"].(map[string]any)
+			out, _ := json.Marshal(map[string]any{"result": args["msg"]})
+			return out
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("server error: %v", err)
+	}
+	defer server.close()
+
+	host, portStr, _ := net.SplitHostPort(server.addr())
+	port, _ := strconv.Atoi(portStr)
+	prov := &UDPProvider{BaseProvider: BaseProvider{Name: "udp", ProviderType: ProviderUDP}, Host: host, Port: port, Timeout: 1000}
+
+	tr := NewUDPTransport(nil)
+	ctx := context.Background()
+	tools, err := tr.RegisterToolProvider(ctx, prov)
+	if err != nil {
+		t.Fatalf("register error: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "udp_echo" {
+		t.Fatalf("unexpected tools: %+v", tools)
+	}
+
+	res, err := tr.CallTool(ctx, "udp_echo", map[string]any{"msg": "hi"}, prov, nil)
+	if err != nil {
+		t.Fatalf("call error: %v", err)
+	}
+	m, ok := res.(map[string]any)
+	if !ok || m["result"] != "hi" {
+		t.Fatalf("unexpected result: %#v", res)
+	}
+}

--- a/utcp_client.go
+++ b/utcp_client.go
@@ -110,6 +110,11 @@ func defaultTransports() map[string]ClientTransport {
 				fmt.Printf("MCP Transport: "+format+"\n", args...)
 			},
 		), // You'll need to implement these
+		"udp": NewUDPTransport(
+			func(format string, args ...interface{}) {
+				fmt.Printf("UDP Transport: "+format+"\n", args...)
+			},
+		),
 		"text": NewTextTransport(""), // You'll need to implement these
 		"graphql": NewGraphQLClientTransport(func(msg string, err error) {
 			fmt.Printf("GraphQL Transport: %s: %v\n", msg, err)

--- a/utcp_client_additional_test.go
+++ b/utcp_client_additional_test.go
@@ -223,7 +223,7 @@ func TestCreateProviderOfTypeAll(t *testing.T) {
 
 func TestDefaultTransportsKeys(t *testing.T) {
 	tr := defaultTransports()
-	keys := []string{"http", "cli", "sse", "http_stream", "mcp", "text", "graphql"}
+	keys := []string{"http", "cli", "sse", "http_stream", "mcp", "udp", "text", "graphql"}
 	for _, k := range keys {
 		if _, ok := tr[k]; !ok {
 			t.Fatalf("missing transport %s", k)


### PR DESCRIPTION
## Summary
- add UDP transport with datagram request/response
- register UDP transport in UTCP client
- update default transport tests
- add UDP transport unit tests
- document UDP support

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687920743324832294b7be6029fbd7e3